### PR TITLE
バトルクラスとcontextでのユーザー情報取得基盤の実装

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,6 +8,9 @@
       "name": "front",
       "version": "0.1.0",
       "dependencies": {
+        "@types/js-cookie": "^3.0.6",
+        "axios": "^1.10.0",
+        "js-cookie": "^3.0.5",
         "next": "15.3.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -953,6 +956,12 @@
         "tailwindcss": "4.1.11"
       }
     },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.7.tgz",
@@ -983,6 +992,23 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -992,6 +1018,19 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1075,12 +1114,33 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.0.4",
@@ -1090,6 +1150,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -1106,12 +1180,190 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
@@ -1128,6 +1380,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/lightningcss": {
@@ -1379,6 +1640,36 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -1552,6 +1843,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.1.0",

--- a/front/package.json
+++ b/front/package.json
@@ -9,16 +9,19 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@types/js-cookie": "^3.0.6",
+    "axios": "^1.10.0",
+    "js-cookie": "^3.0.5",
+    "next": "15.3.5",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.3.5"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/front/src/api/me-index.ts
+++ b/front/src/api/me-index.ts
@@ -1,0 +1,38 @@
+import { ElementType } from "@/types/element-type";
+import { PhysicsType } from "@/types/physics-type";
+import axios from "axios";
+import Cookie from "js-cookie";
+
+export type MeIndexResponse = {
+  id: string;
+  name: string;
+  imageUrl: string;
+  level: number;
+  maxHitPoint: number;
+  hitPoint: number;
+  experiencePoint: number;
+  weapon: {
+    id: number;
+    name: string;
+    imageUrl: string;
+    physicsAttack: number;
+    elementAttack: number | null;
+    physicsType: PhysicsType;
+    elementType: ElementType;
+  };
+};
+
+export function meIndex(): Promise<MeIndexResponse> {
+  const apiUrl = `${process.env.NEXT_PUBLIC_API_URL}/me`;
+  const authToken = Cookie.get("authToken");
+
+  return axios
+    .get<MeIndexResponse>(apiUrl, {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
+    })
+    .then((res) => {
+      return res.data;
+    })
+}

--- a/front/src/api/me-item.ts
+++ b/front/src/api/me-item.ts
@@ -1,0 +1,45 @@
+import { ElementType } from "@/types/element-type";
+import { PhysicsType } from "@/types/physics-type";
+import axios from "axios";
+import Cookie from "js-cookie";
+
+export type MeItemResponse = (
+  | {
+      id: number;
+      name: string;
+      imageUrl: string;
+      effectType: "heal";
+      amount: number;
+    }
+  | {
+      id: number;
+      name: string;
+      imageUrl: string;
+      effectType: "buff";
+      rate: number;
+      target: PhysicsType | ElementType;
+    }
+  | {
+      id: number;
+      name: string;
+      imageUrl: string;
+      effectType: "debuff";
+      rate: number;
+      target: PhysicsType | ElementType;
+    }
+)[];
+
+export function meItem(): Promise<MeItemResponse> {
+  const apiUrl = `${process.env.NEXT_PUBLIC_API_URL}/me/item`;
+  const authToken = Cookie.get("authToken");
+
+  return axios
+    .get<MeItemResponse>(apiUrl, {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
+    })
+    .then((res) => {
+      return res.data;
+    });
+}

--- a/front/src/api/me-weapon.ts
+++ b/front/src/api/me-weapon.ts
@@ -1,0 +1,29 @@
+import { ElementType } from "@/types/element-type";
+import { PhysicsType } from "@/types/physics-type";
+import axios from "axios";
+import Cookie from "js-cookie";
+
+export type MeWeaponResponse = {
+  id: number;
+  name: string;
+  imageUrl: string;
+  physicsAttack: number;
+  elementAttack: number | null;
+  physicsType: PhysicsType;
+  elementType: ElementType;
+}[];
+
+export function meWeapon(): Promise<MeWeaponResponse> {
+  const apiUrl = `${process.env.NEXT_PUBLIC_API_URL}/me/weapon`;
+  const authToken = Cookie.get("authToken");
+
+  return axios
+    .get<MeWeaponResponse>(apiUrl, {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
+    })
+    .then((res) => {
+      return res.data;
+    });
+}

--- a/front/src/app/admin/page.tsx
+++ b/front/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+export default function Page() {
+  return (
+    <div className="h-screen flex justify-center items-center text-4xl">管理者ページ</div>
+  );
+}

--- a/front/src/app/guide/page.tsx
+++ b/front/src/app/guide/page.tsx
@@ -1,0 +1,5 @@
+export default function Page() {
+  return (
+    <div className="h-screen flex justify-center items-center text-4xl">4階で勇者のQRを受け取って冒険を始めよう。</div>
+  );
+}

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { MainLayout } from "@/components/layout/main-layout";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <MainLayout>
+          {children}
+        </MainLayout>
       </body>
     </html>
   );

--- a/front/src/hooks/use-global-context.ts
+++ b/front/src/hooks/use-global-context.ts
@@ -1,0 +1,27 @@
+import { MeIndexResponse } from "@/api/me-index";
+import { MeItemResponse } from "@/api/me-item";
+import { MeWeaponResponse } from "@/api/me-weapon";
+import React, { createContext, useContext } from "react";
+
+type GlobalContextType = {
+  user: MeIndexResponse;
+  setUser: (user: MeIndexResponse) => void;
+  weapons: MeWeaponResponse;
+  setWeapons: (weapons: MeWeaponResponse) => void;
+  items: MeItemResponse;
+  setItems: (items: MeItemResponse) => void;
+};
+
+export const GlobalContext = createContext<GlobalContextType | undefined>(
+  undefined
+);
+
+export function useGlobalContext() {
+  const context = useContext(GlobalContext);
+  if (context === undefined) {
+    throw new Error(
+      "useGlobalContext must be used within a GlobalContextProvider"
+    );
+  }
+  return context;
+}

--- a/front/src/types/element-type.ts
+++ b/front/src/types/element-type.ts
@@ -1,0 +1,1 @@
+export type ElementType = "neutral" | "flame" | "water" | "ice" | "thunder";

--- a/front/src/types/physics-type.ts
+++ b/front/src/types/physics-type.ts
@@ -1,0 +1,1 @@
+export type PhysicsType = "slash" | "blow" | "shoot";

--- a/front/src/utils/battle.ts
+++ b/front/src/utils/battle.ts
@@ -1,0 +1,286 @@
+import { ElementType } from "@/types/element-type";
+import { PhysicsType } from "@/types/physics-type";
+
+type Monster = {
+  attack: number;
+  maxHitPoint: number;
+  hitPoint: number;
+  experiencePoint: number;
+
+  // 物理耐性
+  slash: number;
+  blow: number;
+  shoot: number;
+
+  // 属性耐性
+  neutral: number;
+  flame: number;
+  water: number;
+  ice: number;
+  thunder: number;
+
+  // ドロップアイテム
+  weapon: {
+    id: number;
+    name: string;
+  } | null;
+  item: {
+    id: number;
+    name: string;
+  } | null;
+};
+
+type User = {
+  level: number;
+  maxHitPoint: number;
+  hitPoint: number;
+  experiencePoint: number;
+
+  weapon: Weapon;
+};
+
+type Weapon = {
+  name: string;
+  physicsAttack: number;
+  elementAttack: number | null;
+  physicsType: PhysicsType;
+  elementType: ElementType;
+};
+
+type HeelItem = {
+  name: string;
+  logicType: "heal";
+  amount: number;
+};
+
+type BuffItem = {
+  name: string;
+  logicType: "buff";
+  rate: number; // 何%増加するか
+  target: PhysicsType | ElementType;
+};
+
+type DebuffItem = {
+  name: string;
+  logicType: "debuff";
+  rate: number; // 何%減少するか
+  target: PhysicsType | ElementType;
+};
+
+export class Battle {
+  private user: User;
+  private monster: Monster;
+  private buffs = {
+    slash: 0.0,
+    blow: 0.0,
+    shoot: 0.0,
+    neutral: 0.0,
+    flame: 0.0,
+    water: 0.0,
+    ice: 0.0,
+    thunder: 0.0,
+  };
+  private debuffs = {
+    slash: 0.0,
+    blow: 0.0,
+    shoot: 0.0,
+    neutral: 0.0,
+    flame: 0.0,
+    water: 0.0,
+    ice: 0.0,
+    thunder: 0.0,
+  };
+
+  constructor(user: User, monster: Monster) {
+    this.user = user;
+    this.monster = monster;
+  }
+
+  public attack(): {
+    monsterHitPoint: number;
+    isFinished: boolean;
+    message: string;
+  } {
+    const physicsType = this.user.weapon.physicsType;
+    const elementType = this.user.weapon.elementType;
+    const physics =
+      this.user.weapon.physicsAttack *
+      (1 + this.buffs[physicsType]) *
+      (1 - this.monster[physicsType] * (1 - this.debuffs[physicsType]));
+    const element =
+      (this.user.weapon.elementAttack || 1) *
+      (1 + this.buffs[elementType]) *
+      (1 - this.monster[elementType] * (1 - this.debuffs[elementType]));
+    const random = 0.95 + Math.random() * 0.1;
+
+    // (武器攻撃力*(1+物理バフ)*(1-物理耐性*(1-物理デバフ))) *
+    // (武器属性値*(1+属性バフ)*(1-属性耐性*(1-属性デバフ))) *
+    // (レベル/100) *
+    // 乱数
+    const damage = Math.floor(
+      physics * element * (this.user.level / 100) * random
+    );
+
+    this.monster.hitPoint =
+      damage < 0
+        ? Math.min(this.monster.hitPoint - damage, this.monster.maxHitPoint)
+        : Math.max(this.monster.hitPoint - damage, 0);
+
+    if (this.monster.hitPoint === 0)
+      return {
+        monsterHitPoint: this.monster.hitPoint,
+        isFinished: true,
+        message: "モンスターを倒した！",
+      };
+
+    if (damage === 0)
+      return {
+        monsterHitPoint: this.monster.hitPoint,
+        isFinished: false,
+        message: "モンスターの防御に阻まれた！",
+      };
+
+    if (damage < 0)
+      return {
+        monsterHitPoint: this.monster.hitPoint,
+        isFinished: false,
+        message: `${-damage}ダメージが吸収された！`,
+      };
+
+    return {
+      monsterHitPoint: this.monster.hitPoint,
+      isFinished: false,
+      message: `${damage}のダメージを与えた！`,
+    };
+  }
+
+  public changeWeapon(weapon: Weapon): {
+    message: string;
+  } {
+    this.user.weapon = weapon;
+    return {
+      message: `武器を${weapon.name}に変更した！`,
+    };
+  }
+
+  public useHealItem(item: HeelItem): {
+    userHitPoint: number;
+    message: string;
+  } {
+    const healedAmount = Math.min(
+      item.amount,
+      this.user.maxHitPoint - this.user.hitPoint
+    );
+    this.user.hitPoint += healedAmount;
+    return {
+      userHitPoint: this.user.hitPoint,
+      message: `${healedAmount}回復した！`,
+    };
+  }
+
+  public useBuffItem(item: BuffItem): {
+    message: string;
+  } {
+    this.buffs[item.target] += Math.floor(item.rate * 10) / 10;
+    return {
+      message: `${item.name}を使った！`,
+    };
+  }
+
+  public useDebuffItem(item: DebuffItem): {
+    message: string;
+  } {
+    this.debuffs[item.target] += Math.floor(item.rate * 10) / 10;
+    return {
+      message: `${item.name}を使った！`,
+    };
+  }
+
+  public takeDamage(): {
+    userHitPoint: number;
+    isFinished: boolean;
+    message: string;
+  } {
+    // モンスター攻撃力 * (100/レベル) * 乱数
+    const random = 0.95 + Math.random() * 0.1;
+    const damage = this.monster.attack * (100 / this.user.level) * random;
+
+    this.user.hitPoint = Math.max(this.user.hitPoint - damage, 0);
+
+    if (this.user.hitPoint === 0)
+      return {
+        userHitPoint: this.user.hitPoint,
+        isFinished: true,
+        message: "モンスターに倒された！",
+      };
+
+    return {
+      userHitPoint: this.user.hitPoint,
+      isFinished: false,
+      message: `${damage}のダメージを受けた！`,
+    };
+  }
+
+  public drop(weaponIds: number[]): {
+    drop: {
+      id: number;
+      type: "weapon" | "item";
+    } | null;
+    message: string;
+  } {
+    if (this.monster.weapon && !weaponIds.includes(this.monster.weapon.id)) {
+      return {
+        drop: {
+          id: this.monster.weapon.id,
+          type: "weapon",
+        },
+        message: `${this.monster.weapon?.name}を落とした！`,
+      };
+    }
+
+    if (this.monster.item)
+      return {
+        drop: {
+          id: this.monster.item.id,
+          type: "item",
+        },
+        message: `${this.monster.item?.name}を落とした！`,
+      };
+
+    return {
+      drop: null,
+      message: "何も落とさなかった！",
+    };
+  }
+
+  public grantExperience(): {
+    experiencePoint: number;
+    message: string;
+  } {
+    return {
+      experiencePoint: this.monster.experiencePoint,
+      message: `${this.monster.experiencePoint}の経験値を獲得した！`,
+    };
+  }
+
+  public levelUp(): {
+    level: number;
+    increasedHitPoint: number;
+    message: string;
+  } | null {
+    const level = Math.floor(Math.sqrt(this.user.experiencePoint + 1) / 17);
+
+    if (this.user.level < level) {
+      this.user.level = level;
+      const increasedHitPoint = [17, 18, 19][Math.floor(Math.random() * 3)];
+
+      return {
+        level: this.user.level,
+        increasedHitPoint: increasedHitPoint,
+        message: `レベルが${level}になった！`,
+      };
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
## ブランチ
- `devからfeature/RPG-タスク番号`で行うことにしました

## API
`/me`
- ユーザー情報の取得
`/me/weapon`
- ユーザーが所持している武器一覧の取得
`/me/item`
- ユーザーが所持しているアイテム一覧の取得

## バトルクラス
| メソッド名 | 説明 |
|---|---|
| **`attack`** | ユーザーがモンスターを攻撃するメソッド。 |
| **`changeWeapon`** | ユーザーの武器を変更するメソッド。 |
| ****`useHealItem`**** | 回復アイテムを使用するメソッド。 |
| **`useBuffItem`** | バフアイテムを使用するメソッド。 |
| **`useDebuffItem`** | デバフアイテムを使用するメソッド。 |
| **`takeDamage`** | モンスターからダメージを受けるメソッド。 |
| **`drop`** | アイテムのドロップを処理するメソッド。 |
| **`grantExperience`** | 経験値を獲得するメソッド。 |
| **`levelUp`** | レベルアップを処理するメソッド。 |

## 今後の展望
- `layout.tsx`にuseEffectを追加し、ユーザー情報の変更検知して自動でupdate APIを叩くようにする
- `component`直下を`shared`, `feature`, `layout`の三つに分断
- `/admin`配下に管理者用のページを作成
- `/guide`にQRでログインを促すページを作成
