### PR TITLE
UserとMonsterの主キーをuuidに変更、それに合わせた諸々の修正

### DIFF
--- a/back/app/Models/Monster.php
+++ b/back/app/Models/Monster.php
@@ -3,9 +3,16 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 class Monster extends Model
 {
+    /**
+     * UUIDを主キーとして使用
+     */
+    public $incrementing = false;
+    protected $keyType = 'string';
+
     protected $fillable = [
         'weapon_id',
         'item_id',
@@ -24,4 +31,18 @@ class Monster extends Model
         'shine',
         'dark',
     ];
+
+    /**
+     * モデル作成時に自動でUUIDを生成
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (!$model->getKey()) {
+                $model->{$model->getKeyName()} = (string) Str::uuid();
+            }
+        });
+    }
 }

--- a/back/app/Models/User.php
+++ b/back/app/Models/User.php
@@ -7,11 +7,18 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Illuminate\Support\Str;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable, HasApiTokens;
+
+    /**
+     * UUIDを主キーとして使用
+     */
+    public $incrementing = false;
+    protected $keyType = 'string';
 
     /**
      * The attributes that are mass assignable.
@@ -48,5 +55,19 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    /**
+     * モデル作成時に自動でUUIDを生成
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (!$model->getKey()) {
+                $model->{$model->getKeyName()} = (string) Str::uuid();
+            }
+        });
     }
 }

--- a/back/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/back/database/migrations/0001_01_01_000000_create_users_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id')->primary();
             $table->unsignedBigInteger('weapon_id')->nullable();
             $table->string('name')->unique();
             $table->text('image_url')->nullable();

--- a/back/database/migrations/2025_07_18_125138_create_user_weapons_table.php
+++ b/back/database/migrations/2025_07_18_125138_create_user_weapons_table.php
@@ -12,13 +12,12 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('user_weapons', function (Blueprint $table) {
-            $table->unsignedBigInteger('user_id');
             $table->unsignedBigInteger('weapon_id');
 
-            $table->primary(['user_id', 'weapon_id']);
-
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreignUuid('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->foreign('weapon_id')->references('id')->on('weapons')->onDelete('cascade');
+
+            $table->primary(['user_id', 'weapon_id']);
 
             $table->timestamps();
         });

--- a/back/database/migrations/2025_07_18_130711_create_user_items_table.php
+++ b/back/database/migrations/2025_07_18_130711_create_user_items_table.php
@@ -12,14 +12,14 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('user_items', function (Blueprint $table) {
-            $table->unsignedBigInteger('user_id');
             $table->unsignedBigInteger('item_id');
+
+            $table->foreignUuid('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('item_id')->references('id')->on('items')->onDelete('cascade');
             $table->primary(['user_id', 'item_id']);
+
             $table->unsignedInteger('count');
             $table->timestamps();
-
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
-            $table->foreign('item_id')->references('id')->on('items')->onDelete('cascade');
         });
     }
 

--- a/back/database/migrations/2025_07_18_132029_create_monsters_table.php
+++ b/back/database/migrations/2025_07_18_132029_create_monsters_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('monsters', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id')->primary();
             $table->unsignedBigInteger('weapon_id')->nullable();
             $table->unsignedBigInteger('item_id')->nullable();
             $table->string('name');


### PR DESCRIPTION
## **UserモデルとMonsterモデルの主キーをUUIDに変更**


## 概要

### UserモデルとMonsterモデルの主キーを自動増分整数からUUIDに変更し、自動生成機能を実装しました。

### 変更内容

#### 1. マイグレーションファイルの修正
- `0001_01_01_000000_create_users_table.php`: `$table->id()` → `$table->uuid('id')->primary()`
- `2025_07_18_132029_create_monsters_table.php`: `$table->id()` → `$table->uuid('id')->primary()`

#### 2. モデルの設定変更
**User.php / Monster.php**
```php
// UUIDを主キーとして使用
public $incrementing = false;
protected $keyType = 'string';

// モデル作成時に自動でUUIDを生成
protected static function boot()
{
    parent::boot();
    static::creating(function ($model) {
        if (!$model->getKey()) {
            $model->{$model->getKeyName()} = (string) Str::uuid();
        }
    });
}
```

#### 3. 関連テーブルの外部キー修正
- `create_user_weapons_table.php`: `foreignUuid('user_id')` でUUID外部キー対応
- `create_user_items_table.php`: `foreignUuid('user_id')` でUUID外部キー対応

#### 4. 動作確認用シーダー(今回のタスクではプッシュはしてないです。いずれ作るはずなのでローカルでは作成してます。)
- `UserSeeder`: テストユーザー3人作成
- `MonsterSeeder`: テストモンスター3体作成

### 動作確認
`php artisan migrate:fresh --seed` で実行し、UUID自動生成を確認済み：
- User例: `de44319e-9a6d-47d4-8682-98f5768d4da0`
- Monster例: `035fb16a-91ba-431c-af88-f3adec0cce20`

### 影響
- 新規作成時にUUIDが自動生成される
- 外部キー関係のテーブルもUUID参照に対応